### PR TITLE
docs: build and deploy to github pages

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -1,0 +1,18 @@
+name: building github pages documentation
+
+on:
+  push:
+    branches:
+      - stable
+
+jobs:
+  build-and-deploy:
+    name: building documentation and deploying it on gh-pages branch
+    runs-on: ubuntu-latest
+    steps:
+      - name: pull the code
+        uses: actions/checkout@v2
+      - name: install dependencies
+        run: pip install -r requirements.txt
+      - name: build and deploy
+        run: mkdocs gh-deploy -f docs/en/mkdocs.yml


### PR DESCRIPTION
The new added workflow will only be triggered when merging things on the branch `stable`.
The documentation will be built and deployed in the branch `gh-pages`.
It's now possible to configure github to point the github page to the `gh-pages` branch and it will be automagically deployed 😃
We might have to merge it to the stable branch in order to make it work.

Here is an example of the result: https://jdrouet.github.io/sailfish/

Once this is merged and working, we should update the doc.

Signed-off-by: Jérémie Drouet <jeremie.drouet@gmail.com>