### PR TITLE
Fix github pages deploy action

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -1,6 +1,7 @@
 name: building github pages documentation
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - stable
@@ -12,9 +13,7 @@ jobs:
     steps:
       - name: pull the code
         uses: actions/checkout@v3
-        with:
-             clean: true
       - name: install dependencies
         run: pip install -r requirements.txt
       - name: build and deploy
-        run: mkdocs gh-deploy -f docs/en/mkdocs.yml --clean
+        run: mkdocs gh-deploy -f docs/en/mkdocs.yml --force


### PR DESCRIPTION
Force-pushing seem to be [recommended by Material for MkDocs](https://squidfunk.github.io/mkdocs-material/publishing-your-site/).

I have a working version over at https://svenskunganka.github.io/sailfish/ that was generated via CI in https://github.com/Svenskunganka/sailfish/runs/5505462503

I also added `workflow_dispatch` so that you can [manually run the workflow](https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow) from the Actions-tab here on GitHub if need be. I believe these last few commits on `stable` needs to be ported over to `master` branch for it to show up though.