### PR TITLE
Implement Render trait for Option

### DIFF
--- a/sailfish/src/runtime/render.rs
+++ b/sailfish/src/runtime/render.rs
@@ -362,6 +362,26 @@ impl<T: Render> Render for Wrapping<T> {
     }
 }
 
+impl<T: Render> Render for Option<T> {
+    #[inline]
+    fn render(&self, b: &mut Buffer) -> Result<(), RenderError> {
+        if let Some(inner) = self {
+            inner.render(b)
+        } else {
+            Ok(())
+        }
+    }
+
+    #[inline]
+    fn render_escaped(&self, b: &mut Buffer) -> Result<(), RenderError> {
+        if let Some(inner) = self {
+            inner.render_escaped(b)
+        } else {
+            Ok(())
+        }
+    }
+}
+
 /// The error type which is returned from template function
 #[derive(Clone, Debug)]
 pub enum RenderError {
@@ -519,6 +539,18 @@ mod tests {
         Render::render(&NonZeroU8::new(10).unwrap(), &mut b).unwrap();
         Render::render_escaped(&NonZeroI16::new(-20).unwrap(), &mut b).unwrap();
         assert_eq!(b.as_str(), "10-20");
+    }
+
+    #[test]
+    fn test_option() {
+        let mut b = Buffer::new();
+        Render::render(&Some("apple"), &mut b).unwrap();
+        Render::render_escaped(&Some("apple"), &mut b).unwrap();
+
+        Render::render(&Option::<&str>::None, &mut b).unwrap();
+        Render::render_escaped(&Option::<&str>::None, &mut b).unwrap();
+
+        assert_eq!(b.as_str(), "appleapple");
     }
 
     #[test]


### PR DESCRIPTION
Given a template struct of this:

```rust
#[derive(TemplateOnce)]
#[template(path = "login.stpl")]
struct Login {
  username: Option<String>
}
```

PR allows to do this:

```html
<input type="text" name="username" value="<%= username %>">
```
instead of:
```html
<input type="text" name="username" value="<%= if let Some(usr) = username { usr } %>">
// or
<% if let Some(usr) = username { %>
<input type="text" name="username" value="<%= usr %>">
<% } %>
// or (inefficient, allocates empty String and renders it):
<input type="text" name="username" value="<%= username.unwrap_or_else(|| "".to_owned()) %>">
```

The drawback is that it's easier to accidentally render dead markup, e.g:

```html
<span><%= username %></span>
// When None, results in:
<span></span>
```

I also have an implementation for `Result<T, E>` where `T: Render` over in https://github.com/Svenskunganka/sailfish/tree/render_result but after some consideration I don't think that's a good idea - but please give your opinion as well!