### PR TITLE
Fix of procmacro2 version incompatibility when used with other crates

### DIFF
--- a/sailfish-macros/Cargo.toml
+++ b/sailfish-macros/Cargo.toml
@@ -26,7 +26,7 @@ default = ["config"]
 config = ["sailfish-compiler/config"]
 
 [dependencies]
-proc-macro2 = "1.0.11"
+proc-macro2 = "1.0"
 
 [dependencies.sailfish-compiler]
 path = "../sailfish-compiler"


### PR DESCRIPTION
I believe this fixes Issue #98 and hope that it will allow users of the crate to have more flexibility in which procmacro2 version is used.
