### PR TITLE
Bump proc-macro dependencies

### DIFF
--- a/sailfish-compiler/Cargo.toml
+++ b/sailfish-compiler/Cargo.toml
@@ -35,7 +35,7 @@ default-features = false
 features = ["parsing", "full", "visit-mut", "printing"]
 
 [dependencies.proc-macro2]
-version = ">=1.0.11, <=1.0.43"
+version = ">=1.0.11, <=1.0.46"
 default-features = false
 features = ["span-locations"]
 

--- a/sailfish-macros/Cargo.toml
+++ b/sailfish-macros/Cargo.toml
@@ -26,7 +26,7 @@ default = ["config"]
 config = ["sailfish-compiler/config"]
 
 [dependencies]
-proc-macro2 = "1.0.11"
+proc-macro2 = ">=1.0.11, <=1.0.46"
 
 [dependencies.sailfish-compiler]
 path = "../sailfish-compiler"


### PR DESCRIPTION
The proc-macro2 versions in this crate are a littlebit outdated. This causes version conflicts in projects because of other dependencies with a newer version of proc-macro2.

Bump the version of proc-macro2 to the current version. Also use the same version in all crates.

Tests: ok