### PR TITLE
Shorthand syntax for rendering a TemplateOnce within another template

### DIFF
--- a/docs/en/docs/syntax/overview.md
+++ b/docs/en/docs/syntax/overview.md
@@ -5,6 +5,7 @@
 - `<% %>`: Inline tag, you can write Rust code inside this tag
 - `<%= %>`: Evaluate the Rust expression and outputs the value into the template (HTML escaped)
 - `<%- %>`: Evaluate the Rust expression and outputs the unescaped value into the template
+- `<%^ %>`: Evaluate the Rust expression producing a `TemplateOnce` value, and render that value into the template
 - `<%# %>`: Comment tag
 - `<%%`: Outputs a literal '<%'
 

--- a/docs/en/docs/syntax/tags.md
+++ b/docs/en/docs/syntax/tags.md
@@ -105,3 +105,30 @@ If you want to render the results without escaping, you can use `<%- %>` tag or 
     ``` rhtml
     <% let result = %><%= 1 %><% ; %>
     ```
+
+## Component block
+
+Rust expression inside `<%^ %>` tag is evaluated and then rendered by
+calling its `render_once()` method. If the value does not have an
+appropriate method, a compile-time error will be reported.
+
+This makes it easy to use types which are `TemplateOnce` as components
+which can be embedded into other templates.
+
+=== "Template A"
+
+    ``` rhtml
+    <strong>A <%= val %></strong>
+    ```
+
+=== "Template B"
+
+    ``` rhtml
+    B <%^ A { val: "example" } %>
+    ```
+
+=== "Result"
+
+    ``` text
+    B <strong>A example</strong>
+    ```

--- a/sailfish-compiler/src/parser.rs
+++ b/sailfish-compiler/src/parser.rs
@@ -162,7 +162,7 @@ impl<'a> ParseStream<'a> {
                 token_kind = TokenKind::BufferedCode { escape: false };
                 start += 1;
             }
-            Some(b'^') => {
+            Some(b'+') => {
                 token_kind = TokenKind::NestedTemplateOnce;
                 start += 1;
             }
@@ -409,7 +409,7 @@ mod tests {
 
     #[test]
     fn nested_render_once() {
-        let src = r#"outer <%^ inner|upper %> outer"#;
+        let src = r#"outer <%+ inner|upper %> outer"#;
         let parser = Parser::default();
         let tokens = parser.parse(src).into_vec().unwrap();
         assert_eq!(

--- a/sailfish-compiler/src/translator.rs
+++ b/sailfish-compiler/src/translator.rs
@@ -385,7 +385,7 @@ mod tests {
 
     #[test]
     fn translate_nested_render_once() {
-        let src = r#"outer <%^ inner %> outer"#;
+        let src = r#"outer <%+ inner %> outer"#;
         let lexer = Parser::new();
         let token_iter = lexer.parse(src);
         let mut ps = SourceBuilder {
@@ -407,7 +407,7 @@ mod tests {
 
     #[test]
     fn translate_nested_render_once_with_filter() {
-        let src = r#"outer <%^ inner|upper %> outer"#;
+        let src = r#"outer <%+ inner|upper %> outer"#;
         let lexer = Parser::new();
         let token_iter = lexer.parse(src);
         let mut ps = SourceBuilder {

--- a/sailfish-compiler/src/translator.rs
+++ b/sailfish-compiler/src/translator.rs
@@ -136,6 +136,15 @@ impl SourceBuilder {
         token: &Token<'a>,
         escape: bool,
     ) -> Result<(), Error> {
+        self.write_buffered_code_with_suffix(token, escape, "")
+    }
+
+    fn write_buffered_code_with_suffix<'a>(
+        &mut self,
+        token: &Token<'a>,
+        escape: bool,
+        suffix: &str,
+    ) -> Result<(), Error> {
         // parse and split off filter
         let code_block = syn::parse_str::<CodeBlock>(token.as_str()).map_err(|e| {
             let span = e.span();
@@ -154,7 +163,7 @@ impl SourceBuilder {
         self.source.push_str("!(__sf_buf, ");
 
         if let Some(filter) = code_block.filter {
-            let expr_str = code_block.expr.into_token_stream().to_string();
+            let expr_str = format!("{}{}", code_block.expr.into_token_stream(), suffix);
             let (name, extra_args) = match filter {
                 Filter::Ident(i) => (i.to_string(), None),
                 Filter::Call(c) => (
@@ -188,6 +197,7 @@ impl SourceBuilder {
             self.source.push(')');
         } else {
             self.write_token(token);
+            self.source.push_str(suffix);
         }
 
         self.source.push_str(");\n");
@@ -205,6 +215,11 @@ impl SourceBuilder {
                 TokenKind::BufferedCode { escape } => {
                     self.write_buffered_code(&token, escape)?
                 }
+                TokenKind::NestedTemplateOnce => self.write_buffered_code_with_suffix(
+                    &token,
+                    false,
+                    ".render_once()?",
+                )?,
                 TokenKind::Text => {
                     // concatenate repeated text token
                     let offset = token.offset();
@@ -366,5 +381,49 @@ mod tests {
         };
         ps.feed_tokens(token_iter.clone()).unwrap();
         Translator::new().translate(token_iter).unwrap();
+    }
+
+    #[test]
+    fn translate_nested_render_once() {
+        let src = r#"outer <%^ inner %> outer"#;
+        let lexer = Parser::new();
+        let token_iter = lexer.parse(src);
+        let mut ps = SourceBuilder {
+            escape: true,
+            source: String::with_capacity(token_iter.original_source.len()),
+            source_map: SourceMap::default(),
+        };
+        ps.feed_tokens(token_iter.clone()).unwrap();
+        assert_eq!(
+            &Translator::new()
+                .translate(token_iter)
+                .unwrap()
+                .ast
+                .into_token_stream()
+                .to_string(),
+            r#"{ __sf_rt :: render_text ! (__sf_buf , "outer ") ; __sf_rt :: render ! (__sf_buf , inner . render_once () ?) ; __sf_rt :: render_text ! (__sf_buf , " outer") ; }"#
+        );
+    }
+
+    #[test]
+    fn translate_nested_render_once_with_filter() {
+        let src = r#"outer <%^ inner|upper %> outer"#;
+        let lexer = Parser::new();
+        let token_iter = lexer.parse(src);
+        let mut ps = SourceBuilder {
+            escape: true,
+            source: String::with_capacity(token_iter.original_source.len()),
+            source_map: SourceMap::default(),
+        };
+        ps.feed_tokens(token_iter.clone()).unwrap();
+        assert_eq!(
+            &Translator::new()
+                .translate(token_iter)
+                .unwrap()
+                .ast
+                .into_token_stream()
+                .to_string(),
+            r#"{ __sf_rt :: render_text ! (__sf_buf , "outer ") ; __sf_rt :: render ! (__sf_buf , sailfish :: runtime :: filter :: upper (& (inner . render_once () ?))) ; __sf_rt :: render_text ! (__sf_buf , " outer") ; }"#
+        );
     }
 }


### PR DESCRIPTION
Adds a shorthand syntax for rendering values that are `TemplateOnce` within another template. The syntax is identified by a `^` at the beginning of a code block, similarly to how `=` and `-` identify blocks where a value that is `Render` should be rendered.

The motivation for this is to support modular, component-based templating. I want to be able to create a library of structs which are `TemplateOnce`, and combine them to create pages. Conceptually, this feels like it should not involve writing a lot of code in the higher-level templates. "Render this component at this location" feels like a fundamental operation to me.

While it's already possible to render a value that is `TemplateOnce` and embed the output within another template, doing so has a 15 character overhead at minimum. That's enough to make it unpleasant to work with a component-based architecture in Sailfish. This pull request eliminates that overhead: `<%^ a %>` is equivalent to `<%- a.render_once()? %>` but much more convenient.

Filters are supported, so for example `<%^ a|upper %>` renders `a`'s template and then uppercases its output.

Tests included.