### PR TITLE
Remove procmacro file hack

### DIFF
--- a/sailfish-compiler/src/util.rs
+++ b/sailfish-compiler/src/util.rs
@@ -1,4 +1,3 @@
-use filetime::FileTime;
 use std::fs;
 use std::io::{self, Write};
 use std::path::{Path, PathBuf};
@@ -76,12 +75,4 @@ pub fn rustfmt_block(source: &str) -> io::Result<String> {
             "rustfmt command failed",
         ))
     }
-}
-
-pub fn copy_filetimes(input: &Path, output: &Path) -> io::Result<()> {
-    let mtime = fs::metadata(input)
-        .and_then(|metadata| metadata.modified())
-        .map_or(FileTime::zero(), |time| FileTime::from_system_time(time));
-
-    filetime::set_file_times(output, mtime, mtime)
 }

--- a/sailfish-tests/integration-tests/tests/template_once.rs
+++ b/sailfish-tests/integration-tests/tests/template_once.rs
@@ -1,6 +1,3 @@
-#[macro_use]
-extern crate sailfish_macros;
-
 use integration_tests::assert_string_eq;
 use sailfish::runtime::RenderResult;
 use sailfish::TemplateOnce;


### PR DESCRIPTION
Closes https://github.com/rust-sailfish/sailfish/issues/58  

Currently a file is generated in a proc macro, which is hacky as also stated in the code itself.  
```rust
// FIXME: This is a silly hack to prevent output file from being tracking by
// cargo. Another better solution should be considered.
```
The cargo build-cache evasion seems to not reliably work, which results in a nondeterministic and occasional compile error.  

Now it instead uses a string of the tokens and re-expands it - completely without any file-system operations.  
I did not pay close attention to the surrounding code, but it did not break any tests or my website :smile: 