### PR TITLE
[Breaking] Add `config` feature for `sailfish` crate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## [Unreleased]
+
+### Breaking Change
+
+* Add `config` feature for crate `sailfish`. It is enabled by default. In previous
+  versions, the functionality enabled by the `config` feature was always available. If the
+  feature is disabled, any configuration files (sailfish.toml) are ignored by the template
+  compiler. This speeds up the compiler a bit, and decreases the number of dependencies
+  required, so it can be useful for applications that don't use sailfish.toml configuration
+  files and want to speed up their build process.
+
 <a name="v0.4.0"></a>
 ## [v0.4.0](https://github.com/rust-sailfish/sailfish/compare/v0.3.4...v0.4.0) (2022-03-10)
 

--- a/sailfish-macros/Cargo.toml
+++ b/sailfish-macros/Cargo.toml
@@ -22,7 +22,7 @@ doctest = false
 
 [features]
 default = ["config"]
-# enable configuration file (sailfish.yml) support
+# enable configuration file (sailfish.toml) support
 config = ["sailfish-compiler/config"]
 
 [dependencies]

--- a/sailfish/Cargo.toml
+++ b/sailfish/Cargo.toml
@@ -13,7 +13,9 @@ workspace = ".."
 edition = "2018"
 
 [features]
-default = ["derive", "perf-inline"]
+default = ["config", "derive", "perf-inline"]
+# enable configuration file (sailfish.toml) support
+config = ["sailfish-macros/config"]
 # automatically import derive macro
 derive = ["sailfish-macros"]
 # enable json filter
@@ -30,6 +32,7 @@ serde_json = { version = "1.0.95", optional = true }
 [dependencies.sailfish-macros]
 path = "../sailfish-macros"
 version = "0.6.1"
+default-features = false
 optional = true
 
 [build-dependencies]


### PR DESCRIPTION
This is for enabling the corresponding `config` feature in `sailfish-macros` and `sailfish-compiler`. If it is disabled, configuration files (sailfish.toml) will be ignored. More than 10 cargo build steps can be avoided this way, since the `toml` and `serde` dependencies in `sailfish-compiler` are no longer needed.

This change will break applications that use sailfish.toml and `default-features = false` for the `sailfish` dependency. They need to add `config` to the list of enabled `sailfish` features in Cargo.toml.

Closes #123