### PR TITLE
Cache templates compiled by proc-macro

### DIFF
--- a/sailfish-compiler/src/config.rs
+++ b/sailfish-compiler/src/config.rs
@@ -1,6 +1,6 @@
 use std::path::{Path, PathBuf};
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Hash)]
 pub struct Config {
     pub delimiter: char,
     pub escape: bool,


### PR DESCRIPTION
I'm putting this up as a draft because I'm not convinced I can test it sufficiently. I have tested it a bit and it seems to work for my use case and fixes #58.

Possible disadvantages / risks:

- Files are never deleted from the cache (but `cargo clean` should drop all of them, right?)
- Not sure if the data used for the hash is specific enough, maybe more needs to be taken into account?
- A bunch of unwrap()s :-) Some of them might be problematic, I'm not quite sure which ones though

---
Instead of recompiling sailfish templates on every proc-macro invocation, see if an output file for the same input file content + compiler config combination already exists.

This also fixes #58 because it avoids multiple proc-macro invocations writing to the same output file at roughly the same time from different processes, for example in clippy checks that execute in parallel.

In addition to the compiled output, now the list of dependencies (file names), which was previously generated by the compiler for each template on every proc-macro invocation, needs to be stored to disk for re-use.