### PR TITLE
Update CHANGELOG.md for 0.7.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
-## [Unreleased]
+<a name="v0.7.0"></a>
+## [v0.7.0](https://github.com/rust-sailfish/sailfish/compare/v0.6.1...v0.7.0) (2023-06-22)
 
 ### Breaking Change
 
@@ -12,50 +13,50 @@
 <a name="v0.4.0"></a>
 ## [v0.4.0](https://github.com/rust-sailfish/sailfish/compare/v0.3.4...v0.4.0) (2022-03-10)
 
-## Fix
+### Fix
 
 * Fix some issues pointing to the wrong documentation links
 
-##Breaking Change
+### Breaking Change
 
 * Changed format to .TOML instead of .yaml to better match what Rust uses.
 
 <a name="v0.3.4"></a>
 ## [v0.3.4](https://github.com/rust-sailfish/sailfish/compare/v0.3.3...v0.3.4) (2021-02-13)
 
-## Fix
+### Fix
 
 * Update some dependencies
 
 <a name="v0.3.3"></a>
 ## [v0.3.3](https://github.com/rust-sailfish/sailfish/compare/v0.3.2...v0.3.3) (2021-04-06)
 
-## Fix
+### Fix
 
 * Improve error message for missing semicolon in code blocks
 
 <a name="v0.3.2"></a>
 ## [v0.3.2](https://github.com/rust-sailfish/sailfish/compare/v0.3.1...v0.3.2) (2021-03-29)
 
-## Fix
+### Fix
 
 * Avoid sable/nightly mismatch error caused by proc-macro2 crate 
 
 <a name="v0.3.1"></a>
 ## [v0.3.1](https://github.com/rust-sailfish/sailfish/compare/v0.3.0...v0.3.1) (2021-01-23)
 
-## New Features
+### New Features
 
 * Allow unsized types for filters
 
-## Fix
+### Fix
 
 * Workaround for incorrect cargo fingerprints
 
 <a name="v0.3.0"></a>
 ## [v0.3.0](https://github.com/rust-sailfish/sailfish/compare/v0.2.2...v0.3.0) (2020-12-20)
 
-## Breaking changes
+### Breaking changes
 
 * No longer requires `extern crate sailfish_macros` (which raise compilation warnings with v0.3.0)
 * Remove `TemplaceOnce::render_to_string` method (already deprecated in v0.2.1)
@@ -63,12 +64,12 @@
 * Change `RenderError` into enum
 * Update error format in `sailfish-compiler`
 
-## New features
+### New features
 
 * New filters: `json`, `truncate`
 * Impl `Send`/`Sync` for `Buffer`
 
-## Fix
+### Fix
 
 * Fix rendering issue on continue/break statements
 * Do not panic when buffer size decreased
@@ -78,14 +79,14 @@
 <a name="v0.2.3"></a>
 ## [v0.2.3](https://github.com/rust-sailfish/sailfish/compare/v0.2.2...v0.2.3) (2020-11-29)
 
-## Fix
+### Fix
 
 * Use `std::result::Result` in derive macro to allow custom Result types (#34)
 
 <a name="v0.2.2"></a>
 ## [v0.2.2](https://github.com/rust-sailfish/sailfish/compare/v0.2.1...v0.2.2) (2020-11-11)
 
-## Fix
+### Fix
 
 * Update proc-macro2 version (#32)
 


### PR DESCRIPTION
I didn't expect my PR to be merged and released so quickly, so thanks @Kogia-sima and @vthg2themax!

I prepared a changelog update for 0.7. I believe there were some formatting issues so I fixed them, let me know if that was actually on purpose.

Also, I think the "v0.7.0" tag is missing from github, so before merging this PR, the tag should be added to make the new link work. Edit: I spoke too soon, the tag has just appeared. :-)

0.5.0, 0.6.0 and 0.6.1 are missing from the changelog.

Commit message:
--------
This might help some people who want to know how difficult a 0.6 -> 0.7 upgrade would be for them.

Also fix some markdown issues.