### PR TITLE
Use timestamps for change detection

### DIFF
--- a/sailfish-compiler/src/compiler.rs
+++ b/sailfish-compiler/src/compiler.rs
@@ -12,7 +12,7 @@ use crate::optimizer::Optimizer;
 use crate::parser::Parser;
 use crate::resolver::Resolver;
 use crate::translator::{TranslatedSource, Translator};
-use crate::util::{copy_filetimes, read_to_string, rustfmt_block};
+use crate::util::{read_to_string, rustfmt_block};
 
 #[derive(Default)]
 pub struct Compiler {
@@ -42,34 +42,35 @@ impl Compiler {
         translator.translate(stream)
     }
 
-    pub fn compile_file(
+    pub fn resolve_file(
         &self,
         input: &Path,
-        output: &Path,
-    ) -> Result<CompilationReport, Error> {
-        // TODO: introduce cache system
-
-        let input = input
-            .canonicalize()
-            .map_err(|_| format!("Template file not found: {:?}", input))?;
-
+    ) -> Result<(TranslatedSource, CompilationReport), Error> {
         let include_handler = Arc::new(|child_file: &Path| -> Result<_, Error> {
             Ok(self.translate_file_contents(&*child_file)?.ast)
         });
 
         let resolver = Resolver::new().include_handler(include_handler);
+        let mut tsource = self.translate_file_contents(input)?;
+        let mut report = CompilationReport { deps: Vec::new() };
+
+        let r = resolver.resolve(input, &mut tsource.ast)?;
+        report.deps = r.deps;
+        Ok((tsource, report))
+    }
+
+    pub fn compile_file(
+        &self,
+        input: &Path,
+        tsource: TranslatedSource,
+        output: &Path,
+    ) -> Result<(), Error> {
         let analyzer = Analyzer::new();
         let optimizer = Optimizer::new().rm_whitespace(self.config.rm_whitespace);
 
-        let compile_file = |input: &Path,
+        let compile_file = |mut tsource: TranslatedSource,
                             output: &Path|
-         -> Result<CompilationReport, Error> {
-            let mut tsource = self.translate_file_contents(input)?;
-            let mut report = CompilationReport { deps: Vec::new() };
-
-            let r = resolver.resolve(&*input, &mut tsource.ast)?;
-            report.deps = r.deps;
-
+         -> Result<(), Error> {
             analyzer.analyze(&mut tsource.ast)?;
             optimizer.optimize(&mut tsource.ast);
 
@@ -86,14 +87,10 @@ impl Compiler {
                 .chain_err(|| format!("Failed to write artifact into {:?}", output))?;
             drop(f);
 
-            // FIXME: This is a silly hack to prevent output file from being tracking by
-            // cargo. Another better solution should be considered.
-            let _ = copy_filetimes(input, output);
-
-            Ok(report)
+            Ok(())
         };
 
-        compile_file(&*input, &*output)
+        compile_file(tsource, output)
             .chain_err(|| "Failed to compile template.")
             .map_err(|mut e| {
                 e.source = fs::read_to_string(&*input).ok();

--- a/sailfish-compiler/src/util.rs
+++ b/sailfish-compiler/src/util.rs
@@ -1,4 +1,3 @@
-use filetime::FileTime;
 use std::fs;
 use std::io::{self, Write};
 use std::path::{Path, PathBuf};
@@ -78,10 +77,10 @@ pub fn rustfmt_block(source: &str) -> io::Result<String> {
     }
 }
 
-pub fn copy_filetimes(input: &Path, output: &Path) -> io::Result<()> {
-    let mtime = fs::metadata(input)
+#[cfg(feature = "procmacro")]
+pub fn filetime(input: &Path) -> filetime::FileTime {
+    use filetime::FileTime;
+    fs::metadata(input)
         .and_then(|metadata| metadata.modified())
-        .map_or(FileTime::zero(), |time| FileTime::from_system_time(time));
-
-    filetime::set_file_times(output, mtime, mtime)
+        .map_or(FileTime::zero(), |time| FileTime::from_system_time(time))
 }


### PR DESCRIPTION
This commit changes the caching mechanism to use the timestamp of all included templates instead of hashing the contents of the root template.

The primary downside is that every build now has to parse, transform, and resolve the input templates instead of just reading and hashing the data--I didn't measure how much more expensive this is, but it seems unavoidable if we need information about child templates. Maybe a hacky regex-based approach could work as an alternative to a complete parse.

On the bright side, this approach rebuilds parent templates correctly when a child template has changed, and doesn't require garbage collection for old compiled template files.

Checked correctness manually by setting [`CARGO_LOG=cargo::core::compiler::fingerprint=info`](https://stackoverflow.com/questions/70174147/how-do-i-make-cargo-show-what-files-are-causing-a-rebuild).

Fixes #134 (maybe related to #132?).