### PR TITLE
Fix filename conflict

### DIFF
--- a/sailfish-compiler/src/compiler.rs
+++ b/sailfish-compiler/src/compiler.rs
@@ -83,6 +83,8 @@ impl Compiler {
 
             let mut f = fs::File::create(output)
                 .chain_err(|| format!("Failed to create artifact: {:?}", output))?;
+            writeln!(f, "// Template compiled from: {}", input.display())
+                .chain_err(|| format!("Failed to write artifact into {:?}", output))?;
             writeln!(f, "{}", rustfmt_block(&*string).unwrap_or(string))
                 .chain_err(|| format!("Failed to write artifact into {:?}", output))?;
             drop(f);

--- a/sailfish-compiler/src/procmacro.rs
+++ b/sailfish-compiler/src/procmacro.rs
@@ -238,7 +238,6 @@ fn derive_template_impl(tokens: TokenStream) -> Result<TokenStream, syn::Error> 
         let lock = Lock::new(&lock_path);
         match lock {
             Ok(lock) => {
-
                 let (tsource, report) = compiler.resolve_file(&input_file)?;
 
                 let output_filetime = filetime(&output_file);

--- a/sailfish-compiler/src/procmacro.rs
+++ b/sailfish-compiler/src/procmacro.rs
@@ -105,25 +105,14 @@ fn resolve_template_file(path: &str, template_dirs: &[PathBuf]) -> Option<PathBu
 }
 
 fn filename_hash(path: &Path, config: &Config) -> String {
-    use std::fmt::Write;
-
-    let mut path_with_hash = String::with_capacity(16);
-
-    if let Some(n) = path.file_name() {
-        let mut filename = &*n.to_string_lossy();
-        if let Some(p) = filename.find('.') {
-            filename = &filename[..p];
-        }
-        path_with_hash.push_str(filename);
-        path_with_hash.push('-');
-    }
-
     let mut hasher = DefaultHasher::new();
     config.hash(&mut hasher);
-    let hash = hasher.finish();
-    let _ = write!(path_with_hash, "{:016x}", hash);
+    let config_hash = hasher.finish();
 
-    path_with_hash
+    path.hash(&mut hasher);
+    let path_hash = hasher.finish();
+
+    format!("{:016x}-{:016x}", config_hash, path_hash)
 }
 
 fn with_compiler<T, F: FnOnce(Compiler) -> Result<T, Error>>(
@@ -249,6 +238,7 @@ fn derive_template_impl(tokens: TokenStream) -> Result<TokenStream, syn::Error> 
         let lock = Lock::new(&lock_path);
         match lock {
             Ok(lock) => {
+
                 let (tsource, report) = compiler.resolve_file(&input_file)?;
 
                 let output_filetime = filetime(&output_file);


### PR DESCRIPTION
Fix #137 

I'm honestly not sure what in 0.8.1 caused this issue to surface. Something around when template files are compiled maybe? It was synchronous before? Anyway... This works. Tested it on our project that has probably 30+ templates, many of which have the same file name.

Template filenames will now be gibberish mostly, but they weren't really useful in large projects anyway, since in our case they all started with `same-file-name-as-everywhere-else-<hash>`. Suggestions welcome here, maybe we could reproduce the same folder structure in the `build` directory as we have in `src`? Surely we can't name output files after the absolute path of the source file since we'll hit a filesystem filename size limit quickly. Thinking out loud. Currently, I added a comment into the generated file explaining where the source code of the template came from.