### PR TITLE
Added axum support through an optional feature

### DIFF
--- a/sailfish/Cargo.toml
+++ b/sailfish/Cargo.toml
@@ -22,12 +22,16 @@ derive = ["sailfish-macros"]
 json = ["serde", "serde_json"]
 # add more #[inline] attribute
 perf-inline = []
+# Implement axum's .into_response() for templates
+axum_support = ["axum", "tower-http"]
 
 [dependencies]
 itoap = "1.0.1"
 ryu = "1.0.13"
 serde = { version = "1.0.159", optional = true }
 serde_json = { version = "1.0.95", optional = true }
+axum = { version = "0.7.5", optional = true }
+tower-http = { version = "0.5.2", optional = true }
 
 [dependencies.sailfish-macros]
 path = "../sailfish-macros"

--- a/sailfish/src/axum_support.rs
+++ b/sailfish/src/axum_support.rs
@@ -1,0 +1,44 @@
+use super::TemplateOnce;
+use axum::{
+    http::StatusCode,
+    response::{Html, IntoResponse, Response},
+};
+
+/// Wrapper struct for TemplateOnce that allows us to have custom error messages and a better api for using the Axum framework
+pub struct AxumTemplate<T: TemplateOnce> {
+    template: T,
+    custom_error_message: Option<String>,
+}
+
+impl<T: TemplateOnce> AxumTemplate<T> {
+    /// Create an AxumTemplate from a TemplateOnce struct
+    pub fn from(template: T) -> Self {
+        Self {
+            template,
+            custom_error_message: None,
+        }
+    }
+
+    /// Specify a custom error message to be rendered when template.render_once() returns an RenderError
+    pub fn with_custom_error_message(mut self, message: String) -> Self {
+        self.custom_error_message = Some(message);
+        self
+    }
+}
+
+impl<T> IntoResponse for AxumTemplate<T>
+where
+    T: TemplateOnce,
+{
+    fn into_response(self) -> Response {
+        match self.template.render_once() {
+            Ok(html) => Html(html).into_response(),
+            Err(err) => {
+                let error_message = self.custom_error_message.unwrap_or_else(|| {
+                    format!("Failed to render template. Error: {err}")
+                });
+                (StatusCode::INTERNAL_SERVER_ERROR, error_message).into_response()
+            }
+        }
+    }
+}

--- a/sailfish/src/lib.rs
+++ b/sailfish/src/lib.rs
@@ -100,6 +100,11 @@ pub trait Template: private::Sealed {
     fn render(&self) -> runtime::RenderResult;
 }
 
+#[cfg(feature = "axum_support")]
+mod axum_support;
+#[cfg(feature = "axum_support")]
+pub use axum_support::AxumTemplate;
+
 #[doc(hidden)]
 pub mod private {
     pub trait Sealed {}


### PR DESCRIPTION
Added to "fix" the request https://github.com/rust-sailfish/sailfish/issues/139

I think the documentation could be improved for my code and help would be welcome, since I don't know how to make it better myself.
This doesn't break any functionality but I'm not sure what tests I can even add, or how to, so again, help would be welcome.


This is some sample code, to see how the API looks like
```rs
#[derive(TemplateOnce)]
#[template(path = "test.stpl")]
struct TestTemplate<'a> {
    s: &'a str
}

async fn endpoint_1() -> impl IntoResponse {
    AxumTemplate::from(TestTemplate { s: "test" }).with_custom_error_message("<html><b>Foo</b></html>".to_string())
}

async fn endpoint_2() -> impl IntoResponse {
    AxumTemplate::from(TestTemplate { s: "test" })
}
```

@vthg2themax
