### PR TITLE
Update MSRV to fix CI issues

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
             toolchain: beta
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
-            toolchain: 1.60.0 # MSRV
+            toolchain: 1.66.0 # MSRV
           - os: ubuntu-latest
             deps: sudo apt update ; sudo apt install gcc-multilib
             target: i686-unknown-linux-gnu


### PR DESCRIPTION
Updating MSRV to 1.66.0 fixes the CI Issues since dependencies now require at least version 1.66.0