### PR TITLE
Implement rm_newline

### DIFF
--- a/sailfish-compiler/src/compiler.rs
+++ b/sailfish-compiler/src/compiler.rs
@@ -66,7 +66,9 @@ impl Compiler {
         output: &Path,
     ) -> Result<(), Error> {
         let analyzer = Analyzer::new();
-        let optimizer = Optimizer::new().rm_whitespace(self.config.rm_whitespace);
+        let optimizer = Optimizer::new()
+            .rm_whitespace(self.config.rm_whitespace)
+            .rm_newline(self.config.rm_newline);
 
         let compile_file = |mut tsource: TranslatedSource,
                             output: &Path|
@@ -116,7 +118,9 @@ impl Compiler {
         let parser = Parser::new().delimiter(self.config.delimiter);
         let translator = Translator::new().escape(self.config.escape);
         let resolver = Resolver::new().include_handler(include_handler);
-        let optimizer = Optimizer::new().rm_whitespace(self.config.rm_whitespace);
+        let optimizer = Optimizer::new()
+            .rm_whitespace(self.config.rm_whitespace)
+            .rm_newline(self.config.rm_newline);
 
         let compile = || -> Result<String, Error> {
             let stream = parser.parse(input);

--- a/sailfish-compiler/src/config.rs
+++ b/sailfish-compiler/src/config.rs
@@ -5,6 +5,7 @@ pub struct Config {
     pub delimiter: char,
     pub escape: bool,
     pub rm_whitespace: bool,
+    pub rm_newline: bool,
     pub template_dirs: Vec<PathBuf>,
     #[doc(hidden)]
     pub cache_dir: PathBuf,
@@ -20,6 +21,7 @@ impl Default for Config {
             escape: true,
             cache_dir: Path::new(env!("OUT_DIR")).join("cache"),
             rm_whitespace: false,
+            rm_newline: false,
             _non_exhaustive: (),
         }
     }
@@ -82,6 +84,10 @@ mod imp {
                         if let Some(rm_whitespace) = optimizations.rm_whitespace {
                             config.rm_whitespace = rm_whitespace;
                         }
+
+                        if let Some(rm_newline) = optimizations.rm_newline {
+                            config.rm_newline = rm_newline;
+                        }
                     }
                 }
 
@@ -96,6 +102,7 @@ mod imp {
     #[serde(deny_unknown_fields)]
     struct Optimizations {
         rm_whitespace: Option<bool>,
+        rm_newline: Option<bool>,
     }
 
     #[derive(Deserialize, Debug)]

--- a/sailfish-compiler/src/procmacro.rs
+++ b/sailfish-compiler/src/procmacro.rs
@@ -24,6 +24,7 @@ struct DeriveTemplateOptions {
     delimiter: Option<LitChar>,
     escape: Option<LitBool>,
     rm_whitespace: Option<LitBool>,
+    rm_newline: Option<LitBool>,
 }
 
 impl DeriveTemplateOptions {
@@ -49,6 +50,8 @@ impl DeriveTemplateOptions {
                     self.escape = Some(s.parse::<LitBool>()?);
                 } else if key == "rm_whitespace" {
                     self.rm_whitespace = Some(s.parse::<LitBool>()?);
+                } else if key == "rm_newline" {
+                    self.rm_newline = Some(s.parse::<LitBool>()?);
                 } else {
                     return Err(syn::Error::new(
                         key.span(),
@@ -80,6 +83,9 @@ fn merge_config_options(config: &mut Config, options: &DeriveTemplateOptions) {
     }
     if let Some(ref rm_whitespace) = options.rm_whitespace {
         config.rm_whitespace = rm_whitespace.value;
+    }
+    if let Some(ref rm_newline) = options.rm_newline {
+        config.rm_newline = rm_newline.value;
     }
 }
 

--- a/sailfish-tests/integration-tests/templates/rm_newline.out
+++ b/sailfish-tests/integration-tests/templates/rm_newline.out
@@ -1,0 +1,1 @@
+<div>  <span>1</span>  <span>2</span>  <span>3</span></div><div>  trailing spaces     This line should be appeared on the same line as the previous line</div>  <div>foo</div>  <div>bar</div>

--- a/sailfish-tests/integration-tests/templates/rm_newline.stpl
+++ b/sailfish-tests/integration-tests/templates/rm_newline.stpl
@@ -1,0 +1,13 @@
+<div>
+  <span>1</span>
+  <span>2</span>
+
+  <span>3</span>
+</div>
+<div>
+  trailing spaces   
+  This line should be appeared on the same line as the previous line
+</div>
+<% for msg in self.messages { %>
+  <div><%= msg %></div>
+<% } %>

--- a/sailfish-tests/integration-tests/templates/rm_newline_s.stpl
+++ b/sailfish-tests/integration-tests/templates/rm_newline_s.stpl
@@ -1,0 +1,13 @@
+<div>
+  <span>1</span>
+  <span>2</span>
+
+  <span>3</span>
+</div>
+<div>
+  trailing spaces   
+  This line should be appeared on the same line as the previous line
+</div>
+<% for msg in messages { %>
+  <div><%= msg %></div>
+<% } %>

--- a/sailfish-tests/integration-tests/templates/rm_whitespace_newline.out
+++ b/sailfish-tests/integration-tests/templates/rm_whitespace_newline.out
@@ -1,0 +1,1 @@
+<div><span>1</span><span>2</span><span>3</span></div><div>trailing spacesThis line should be appeared on the same line as the previous line</div><div>foo</div><div>bar</div>

--- a/sailfish-tests/integration-tests/templates/rm_whitespace_newline.stpl
+++ b/sailfish-tests/integration-tests/templates/rm_whitespace_newline.stpl
@@ -1,0 +1,13 @@
+<div>
+  <span>1</span>
+  <span>2</span>
+
+  <span>3</span>
+</div>
+<div>
+  trailing spaces   
+  This line should be appeared on the same line as the previous line
+</div>
+<% for msg in self.messages { %>
+  <div><%= msg %></div>
+<% } %>

--- a/sailfish-tests/integration-tests/templates/rm_whitespace_newline_s.stpl
+++ b/sailfish-tests/integration-tests/templates/rm_whitespace_newline_s.stpl
@@ -1,0 +1,13 @@
+<div>
+  <span>1</span>
+  <span>2</span>
+
+  <span>3</span>
+</div>
+<div>
+  trailing spaces   
+  This line should be appeared on the same line as the previous line
+</div>
+<% for msg in messages { %>
+  <div><%= msg %></div>
+<% } %>

--- a/sailfish-tests/integration-tests/tests/template.rs
+++ b/sailfish-tests/integration-tests/tests/template.rs
@@ -221,6 +221,40 @@ fn test_rm_whitespace() {
 }
 
 #[derive(Template)]
+#[template(path = "rm_newline.stpl")]
+#[template(rm_newline = true)]
+struct RmNewline<'a, 'b> {
+    messages: &'a [&'b str],
+}
+
+#[test]
+fn test_rm_newline() {
+    assert_render(
+        "rm_newline",
+        RmNewline {
+            messages: &["foo", "bar"],
+        },
+    );
+}
+
+#[derive(Template)]
+#[template(path = "rm_newline.stpl")]
+#[template(rm_whitespace = true, rm_newline = true)]
+struct RmWhitespaceNewline<'a, 'b> {
+    messages: &'a [&'b str],
+}
+
+#[test]
+fn test_rm_whitespace_newline() {
+    assert_render(
+        "rm_whitespace_newline",
+        RmWhitespaceNewline {
+            messages: &["foo", "bar"],
+        },
+    );
+}
+
+#[derive(Template)]
 #[template(path = "comment.stpl")]
 struct Comment {}
 


### PR DESCRIPTION
Currently, there is an option called `rm_whitespace` that removes all leading and trailing whitespaces from each line in the templates. According to the [Unicode Derived Core Property](https://www.unicode.org/reports/tr44/#White_Space), whitespace includes newlines, so I initially expected that enabling `rm_whitespace` would also remove newlines. However, I discovered that the current implementation explicitly retains newlines for some reason.

To avoid disrupting this existing behavior, which some users may rely on, I have added a new option called `rm_newline` that removes all newlines from the templates.

Please note that `rm_newline` can also be used when `rm_whitespace` is disabled.