### PR TITLE
allow the creation of "language regions" in syntax highlighting

### DIFF
--- a/syntax/vim/syntax/sailfish.vim
+++ b/syntax/vim/syntax/sailfish.vim
@@ -3,14 +3,22 @@
 " Maintainer: Ryohei Machida <orcinus4627@gmail.com>
 " License: MIT
 
+let main_syntax = 'sailfish'
 runtime! syntax/html.vim
 unlet b:current_syntax
 
 syn include @rustSyntax syntax/rust.vim
+unlet b:current_syntax
+
+syn include @cppSyntax syntax/cpp.vim
 
 syn region sailfishCodeBlock matchgroup=sailfishTag start=/<%/ keepend end=/%>/ contains=@rustSyntax
 syn region sailfishBufferBlock matchgroup=sailfishTag start=/<%=/ keepend end=/%>/ contains=@rustSyntax
 syn region sailfishCommentBlock start=/<%#/ end=/%>/
+
+syn region sailfishLanguageBlockCpp matchgroup=sailfishTag start=/<%#\s*#language:cpp\s*%>/ keepend end=/<%#\s*#endlanguage\s*%>/ contains=@cppSyntax,sailfishCodeBlock,sailfishBufferBlock,sailfishCommentBlock
+syn region sailfishLanguageBlockRust matchgroup=sailfishTag start=/<%#\s*#language:rust\s*%>/ keepend end=/<%#\s*#endlanguage\s*%>/ contains=@rustSyntax,sailfishCodeBlock,sailfishBufferBlock,sailfishCommentBlock
+
 
 " Redefine htmlTag so that it can contain jspExpr
 syn clear htmlString

--- a/syntax/vscode/syntaxes/sailfish.tmLanguage.json
+++ b/syntax/vscode/syntaxes/sailfish.tmLanguage.json
@@ -357,6 +357,9 @@
   "name": "sailfish",
   "patterns": [
     {
+      "include": "#languagemarkerblock"
+    },
+    {
       "include": "#commentblock"
     },
     {
@@ -367,6 +370,79 @@
     }
   ],
   "repository": {
+    "languagemarkerblock": {
+      "patterns": [
+        {
+          "name": "meta.block.embedded.cpp",
+          "begin": "<(%|\\?)#\\s*#language:cpp\\s*(%|\\?)>",
+          "beginCaptures": {
+            "0": {
+              "name": "punctuation.definition.tag.begin.html"
+            }
+          },
+          "end": "<(%|\\?)#\\s*#endlanguage\\s*(%|\\?)>",
+          "endCaptures": {
+            "0": {
+              "name": "punctuation.definition.tag.end.html"
+            }
+          },
+          "patterns": [
+            {
+              "include": "$self"
+            },
+            {
+              "include": "source.cpp"
+            }
+          ]
+        },
+        {
+          "name": "meta.block.embedded.rust",
+          "begin": "<(%|\\?)#\\s*#language:rust\\s*(%|\\?)>",
+          "beginCaptures": {
+            "0": {
+              "name": "punctuation.definition.tag.begin.html"
+            }
+          },
+          "end": "<(%|\\?)#\\s*#endlanguage\\s*(%|\\?)>",
+          "endCaptures": {
+            "0": {
+              "name": "punctuation.definition.tag.end.html"
+            }
+          },
+          "patterns": [
+            {
+              "include": "$self"
+            },
+            {
+              "include": "source.rust"
+            }
+          ]
+        },
+        {
+          "name": "meta.block.embedded.html",
+          "begin": "<(%|\\?)#\\s*#language:html\\s*(%|\\?)>",
+          "beginCaptures": {
+            "0": {
+              "name": "punctuation.definition.tag.begin.html"
+            }
+          },
+          "end": "<(%|\\?)#\\s*#endlanguage\\s*(%|\\?)>",
+          "endCaptures": {
+            "0": {
+              "name": "punctuation.definition.tag.end.html"
+            }
+          },
+          "patterns": [
+            {
+              "include": "$self"
+            },
+            {
+              "include": "text.html.basic"
+            }
+          ]
+        }
+      ]
+    },
     "commentblock": {
       "patterns": [
         {
@@ -384,7 +460,7 @@
     "codeblock": {
       "patterns": [
         {
-          "name": "source.rust.embedded.html",
+          "name": "meta.block.embedded.rust",
           "begin": "<(%|\\?)(=|-)?",
           "beginCaptures": {
             "0": {


### PR DESCRIPTION
- use a comment block containing `#language:<name>` to start a language region e.g. `<%# #langauge:cpp %>`
- use a comment block containing `#endlanguage` to end a region e.g. `<%# #endlangauge $>`

for now, contains definitions for `rust`, `cpp`, and `html` blocks in vscode and vim syntax

<img width="486" height="554" alt="image" src="https://github.com/user-attachments/assets/70101eb9-53ef-4d0a-8404-75f9f876b69a" />

best fix I came come up with for #167 