### PR TITLE
Bump optional toml dependency from 0.8 to 1

### DIFF
--- a/sailfish-compiler/Cargo.toml
+++ b/sailfish-compiler/Cargo.toml
@@ -25,7 +25,7 @@ config = ["serde", "toml"]
 memchr = "2.5.0"
 quote = { version = "1.0.26", default-features = false }
 serde = { version = "1.0", features = ["derive"], optional = true }
-toml = { version = "0.8.2", optional = true }
+toml = { version = "1", optional = true }
 home = "0.5.4"
 filetime = "0.2.21"
 


### PR DESCRIPTION
Bumps the optional toml dependency in sailfish-compiler from 0.8.2 to 1. Most consumers presumably use toml 1.x; this avoids compiling both toml 0.8 and 1.x side by side.