### PR TITLE
Potential fix for code scanning alert no. 11: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,9 @@ name: Tests
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Potential fix for [https://github.com/rust-sailfish/sailfish/security/code-scanning/11](https://github.com/rust-sailfish/sailfish/security/code-scanning/11)

Add an explicit top-level `permissions` block in `.github/workflows/test.yml` so all jobs inherit minimal required token scope unless overridden.  
Best fix without changing behavior: set:

- `permissions:`
  - `contents: read`

This is sufficient for `actions/checkout` and read-only CI tasks shown here, and documents intent while preventing future default-permission drift.  
Edit region: near the top of `.github/workflows/test.yml`, directly after `on:` and before `jobs:`.

No new imports, methods, or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
